### PR TITLE
Update build-and-test-sandreco.yml

### DIFF
--- a/.github/workflows/build-and-test-sandreco.yml
+++ b/.github/workflows/build-and-test-sandreco.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test-sandreco:
     strategy:
       matrix:
-        sand-geometry: [SAND_opt1_STT1, SAND_opt2_STT1, SAND_opt3_STT1, SAND_opt2_STT3, SAND_opt3_DRIFT1]
+        sand-geometry: [SAND_opt3_STT1, SAND_opt3_DRIFT1]
     runs-on: ubuntu-latest
     container: almalinux/9-base
     steps:


### PR DESCRIPTION
SAND_opt1_(STT1|STT3) and SAND_opt2_STT1 removed from CI since they are no more supported